### PR TITLE
Remove ntpd, reload apparmor

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,7 @@ maintainer_email 'nd@kaeufli.ch'
 license          'MIT'
 description      'Installs/Configures openntpd'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'
+
+supports 'ubuntu', '>= 12.04'
+supports 'debian'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,15 +24,15 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-package 'ntp' do
-  action :purge
-  notifies :run, 'execute[openntpd reload apparmor]', :immediately
+execute 'forget ntpd apparmor profile' do
+  action :run
+  command 'apparmor_parser -R /etc/apparmor.d/usr.sbin.ntpd'
+  only_if { node.platform == 'ubuntu' && node.platform_version >= '12.04'}
+  only_if { File::exists? '/etc/apparmor.d/usr.sbin.ntpd' }
 end
 
-execute 'openntpd reload apparmor' do
-  action :nothing
-  command 'test -x /etc/init.d/apparmor && /etc/init.d/apparmor reload'
-  only_if { node.platform == 'ubuntu' && node.platform_version >= '12.04'}
+package 'ntp' do
+  action :purge
 end
 
 package 'openntpd' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,6 +24,17 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
+package 'ntp' do
+  action :purge
+  notifies :run, 'execute[openntpd reload apparmor]', :immediately
+end
+
+execute 'openntpd reload apparmor' do
+  action :nothing
+  command 'test -x /etc/init.d/apparmor && /etc/init.d/apparmor reload'
+  only_if { node.platform == 'ubuntu' && node.platform_version >= '12.04'}
+end
+
 package 'openntpd' do
   action :install
 end


### PR DESCRIPTION
"openntpd" replaces "ntp" on Ubuntu.

dpkg will fail on post-install of openntpd with:
  Starting openntpd: /etc/openntpd/ntpd.conf: Permission denied

if the ntp apparmor profile is still applied.
Even after the ntp package purge, it's still in the cache.
